### PR TITLE
Founder Command Center dashboard prototype

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,27 +1,146 @@
-import React from 'react'
-import { StaticQuery, graphql } from 'gatsby'
-import Layout from "../layouts/index"
-import Img from 'gatsby-image'
+import React from "react";
+import { StaticQuery, graphql } from "gatsby";
+import Layout from "../layouts/index";
+
+const healthStats = [
+  { label: "Net revenue (today)", value: "₹4,82,300", trend: "+12.4%" },
+  { label: "Net revenue (week)", value: "₹31,95,000", trend: "+9.1%" },
+  { label: "Net profit estimate", value: "₹7,86,000", trend: "+5.8%" },
+  { label: "Cash at risk", value: "₹2,10,000", trend: "Needs review" },
+  { label: "Stockout risks", value: "7 SKUs", trend: "3 critical" },
+  { label: "Refund rate", value: "4.1%", trend: "-0.6%" }
+];
+
+const approvals = [
+  {
+    title: "Restock SKU-YOGA-MAT",
+    proposedBy: "COO",
+    supportedBy: "CFO",
+    reason: "Stock cover in 4.8 days with velocity +18% WoW.",
+    cost: "₹1,25,000",
+    upside: "₹3,40,000 incremental gross revenue",
+    risk: "Top seller stockout in under 5 days",
+    confidence: "0.87"
+  },
+  {
+    title: "Raise serum price by 6%",
+    proposedBy: "CFO",
+    supportedBy: "CMO",
+    reason: "Margin compression from shipping and packaging costs.",
+    cost: "No direct cost",
+    upside: "+3.2pp category margin",
+    risk: "Conversion dip if messaging is weak",
+    confidence: "0.74"
+  },
+  {
+    title: "Pause Meta ads for SKU-FOAM-ROLLER",
+    proposedBy: "CMO",
+    supportedBy: "CFO",
+    reason: "ROAS below 1.8 for 48h with spend above threshold.",
+    cost: "Opportunity cost only",
+    upside: "Protect ₹45,000/week in inefficient spend",
+    risk: "Loss of top-funnel traffic on this SKU",
+    confidence: "0.91"
+  }
+];
+
+const redFlags = [
+  "ROAS crash in paid social for Home Fitness segment (severity: high)",
+  "Delayed shipments +32% in west zone over last 48h (severity: high)",
+  "Vendor concentration risk: 31% GMV tied to top vendor (severity: medium)",
+  "Refund spike on SKU-CUTTING-BOARD due to quality complaints (severity: medium)"
+];
+
+const opportunities = [
+  "Scale winner: SKINCARE-SERUM has margin >60% and repeat rate at 44%",
+  "Bundle candidate: YOGA-MAT + FOAM-ROLLER with discounted checkout offer",
+  "Retention move: Launch 7/14/30 day post-purchase flow for Smart Bottle segment",
+  "Dead-stock clearance: Create “kitchen essentials” bundle for slow moving SKUs"
+];
+
+const roles = [
+  {
+    role: "CFO",
+    auto:
+      "Flag suspicious spend, tighten ad budget within safe band, mark negative margin SKUs",
+    wait:
+      "Price increases above safe band, budget reallocation, refund exceptions",
+    never: "Brand positioning, market expansion, debt/financing commitments"
+  },
+  {
+    role: "COO",
+    auto:
+      "Low-stock alerts, procurement drafts under cap, out-of-stock campaign pause requests",
+    wait: "Large restocks, supplier switch, aggressive dead-stock discounting",
+    never:
+      "Warehouse migration, long-term supplier contracts, sourcing region changes"
+  },
+  {
+    role: "CMO",
+    auto:
+      "Pause poor ROAS ad sets, micro budget shifts, trigger lifecycle email tests",
+    wait: "Large campaigns, new channels, major discount programs",
+    never: "Brand overhauls, strategic expansion commitments, agency lock-ins"
+  },
+  {
+    role: "Support",
+    auto:
+      "Tracking replies, FAQ responses, policy-matching refunds under threshold",
+    wait:
+      "VIP exceptions, high-value refunds, reputation-sensitive escalations",
+    never: "Legal threats, crisis comms, policy rewrites"
+  }
+];
+
+const eventLog = [
+  {
+    event: "STOCKOUT_RISK",
+    source: "COO",
+    target: "Founder queue",
+    action: "Recommend urgent restock with cash impact estimate"
+  },
+  {
+    event: "AD_ROAS_DROP",
+    source: "CMO",
+    target: "CFO + Founder queue",
+    action:
+      "Auto-pause under threshold and request budget reallocation approval"
+  },
+  {
+    event: "REFUND_SPIKE",
+    source: "Support",
+    target: "COO + CEO",
+    action: "Route defect trend to operations with SKU-level evidence"
+  }
+];
+
+const sourceMap = [
+  {
+    area: "Commerce",
+    sources: "WooCommerce orders, products, refunds, stock, coupons"
+  },
+  {
+    area: "Marketing",
+    sources: "Meta Ads, Google Ads, TikTok Ads, email platform, GA4"
+  },
+  {
+    area: "Operations",
+    sources: "Shipping events, warehouse timelines, supplier lead-time signals"
+  },
+  {
+    area: "Support",
+    sources: "Helpdesk/chat inbox, reviews, CSAT and complaint tags"
+  },
+  {
+    area: "Finance",
+    sources: "Gateway settlements, COGS metadata, payout and tax records"
+  }
+];
 
 export default () => (
   <StaticQuery
     query={graphql`
-      query CatalogueQuery {
-        products: allDatoCmsProduct {
-          edges {
-            node {
-              id
-              name
-              price
-              image {
-                url
-                sizes(maxWidth: 300, imgixParams: { fm: "jpg" }) {
-                  ...GatsbyDatoCmsSizes
-                }
-              }
-            }
-          }
-        }
+      query FounderDashboardQuery {
         site {
           siteMetadata {
             siteName
@@ -29,37 +148,136 @@ export default () => (
         }
       }
     `}
-render={data => (
-  <Layout site={data.site}>
-    <div className="Catalogue">
-      {
-        data.products.edges.map(({ node: product }) => (
-          <div className="Catalogue__item" key={product.id}>
-            <div
-              className="Product snipcart-add-item"
-              data-item-id={product.id}
-              data-item-price={product.price}
-              data-item-image={product.image.url}
-              data-item-name={product.name}
-              data-item-url={`/`}
-            >
-              <div className="Product__image">
-                <Img sizes={product.image.sizes} />
-              </div> <div className="Product__details">
-                <div className="Product__name">
-                  {product.name}
-                  <div className="Product__price">
-                    {product.price}€
-                  </div>
-                </div>
-                <span className="Product__buy">Buy now</span>
-              </div>
+    render={data => (
+      <Layout site={data.site}>
+        <main className="Board">
+          <section className="Board__hero">
+            <p className="Board__eyebrow">AI BOARD OPERATING SYSTEM</p>
+            <h2>Founder Command Center</h2>
+            <p>
+              A decision system that detects, decides, delegates, and escalates
+              with bounded agent authority.
+            </p>
+          </section>
+
+          <section className="Board__section">
+            <h3>Today&apos;s Health</h3>
+            <div className="BoardGrid BoardGrid--stats">
+              {healthStats.map(item => (
+                <article key={item.label} className="Card">
+                  <p className="Card__label">{item.label}</p>
+                  <p className="Card__value">{item.value}</p>
+                  <p className="Card__meta">{item.trend}</p>
+                </article>
+              ))}
             </div>
-          </div>
-        ))
-      }
-    </div>
-  </Layout>
-     )}
-   />
-)
+          </section>
+
+          <section className="Board__section">
+            <h3>Approval Queue</h3>
+            <div className="BoardGrid">
+              {approvals.map(item => (
+                <article key={item.title} className="Card Card--approval">
+                  <h4>{item.title}</h4>
+                  <p>
+                    <strong>Proposed by:</strong> {item.proposedBy} ·{" "}
+                    <strong>Supported by:</strong> {item.supportedBy}
+                  </p>
+                  <p>{item.reason}</p>
+                  <ul>
+                    <li>
+                      <strong>Cost:</strong> {item.cost}
+                    </li>
+                    <li>
+                      <strong>Upside:</strong> {item.upside}
+                    </li>
+                    <li>
+                      <strong>Risk if ignored:</strong> {item.risk}
+                    </li>
+                    <li>
+                      <strong>Confidence:</strong> {item.confidence}
+                    </li>
+                  </ul>
+                  <div className="Card__actions">
+                    <button type="button">Approve</button>
+                    <button type="button">Hold</button>
+                    <button type="button">Reject</button>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </section>
+
+          <section className="Board__section BoardGrid BoardGrid--two">
+            <article className="Card">
+              <h3>Red Flags</h3>
+              <ul>
+                {redFlags.map(flag => (
+                  <li key={flag}>{flag}</li>
+                ))}
+              </ul>
+            </article>
+            <article className="Card">
+              <h3>Weekly Opportunities</h3>
+              <ul>
+                {opportunities.map(item => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </article>
+          </section>
+
+          <section className="Board__section">
+            <h3>Decision Rights Matrix</h3>
+            <div className="TableWrap">
+              <table className="BoardTable">
+                <thead>
+                  <tr>
+                    <th>Agent</th>
+                    <th>Auto-execute</th>
+                    <th>Recommend &amp; wait</th>
+                    <th>Never decide</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {roles.map(row => (
+                    <tr key={row.role}>
+                      <td>{row.role}</td>
+                      <td>{row.auto}</td>
+                      <td>{row.wait}</td>
+                      <td>{row.never}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="Board__section BoardGrid BoardGrid--two">
+            <article className="Card">
+              <h3>Source of Truth Map</h3>
+              <ul>
+                {sourceMap.map(item => (
+                  <li key={item.area}>
+                    <strong>{item.area}:</strong> {item.sources}
+                  </li>
+                ))}
+              </ul>
+            </article>
+            <article className="Card">
+              <h3>Event Handoff Log (sample)</h3>
+              <ul>
+                {eventLog.map(item => (
+                  <li key={item.event}>
+                    <strong>{item.event}:</strong> {item.source} → {item.target}
+                    . {item.action}.
+                  </li>
+                ))}
+              </ul>
+            </article>
+          </section>
+        </main>
+      </Layout>
+    )}
+  />
+);

--- a/src/style/Board.scss
+++ b/src/style/Board.scss
@@ -1,0 +1,93 @@
+.Board {
+  padding: 2rem 0 3rem;
+}
+
+.Board__hero {
+  margin-bottom: 1.5rem;
+  border: 4px solid #000;
+  padding: 1.5rem;
+  background: #f4f4f4;
+}
+
+.Board__eyebrow {
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  margin-bottom: 0.4rem;
+}
+
+.Board__section {
+  margin-bottom: 1.5rem;
+}
+
+.BoardGrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.BoardGrid--stats {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.BoardGrid--two {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.Card {
+  border: 3px solid #000;
+  background: #fff;
+  padding: 1rem;
+}
+
+.Card ul {
+  list-style: disc;
+  margin-left: 1rem;
+}
+
+.Card__label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+}
+
+.Card__value {
+  font-size: 1.25rem;
+  margin: 0.25rem 0;
+}
+
+.Card__meta {
+  font-size: 0.9rem;
+}
+
+.Card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.Card__actions button {
+  border: 2px solid #000;
+  background: #fff;
+  font-size: 0.85rem;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 0.3rem 0.6rem;
+}
+
+.TableWrap {
+  overflow-x: auto;
+}
+
+.BoardTable {
+  width: 100%;
+  border-collapse: collapse;
+  border: 3px solid #000;
+  background: #fff;
+}
+
+.BoardTable th,
+.BoardTable td {
+  border: 2px solid #000;
+  padding: 0.55rem;
+  vertical-align: top;
+  text-align: left;
+}

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -8,3 +8,5 @@
 @import "Footer";
 
 @import "snipcart";
+
+@import "Board";


### PR DESCRIPTION
### Motivation
- Turn the AI Board Operating System spec into a buildable, founder-facing UI to validate data contracts and approval/decision workflows.
- Provide a single-screen `Founder Command Center` homepage that surfaces health, approval queue, red flags, opportunities, decision-rights, and event handoffs instead of the product catalogue.
- No external skill was used; the changes were implemented directly in the repository to prototype the UX and data contracts.

### Description
- Replaced the product-catalogue homepage with a dashboard implemented in `src/pages/index.js` that renders health stats, an approval queue, red flags, weekly opportunities, a decision-rights matrix, a source-of-truth map, and a sample event handoff log using representative static data.
- Added a dedicated stylesheet `src/style/Board.scss` and imported it via `src/style/index.scss` to style the dashboard grid, cards, table, and actions.
- Preserved the Gatsby `StaticQuery` for `site.siteMetadata` and retained the existing layout composition so the dashboard fits the current app architecture.

### Testing
- Ran `yarn format` which formatted the modified files and completed successfully.
- Ran `npx prettier --write src/pages/index.js src/style/index.scss src/style/Board.scss` which succeeded.
- Ran `npx prettier --check src/pages/index.js src/style/index.scss src/style/Board.scss` which reported all files match Prettier style.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a9325e9c832b95c856b95862cc9d)